### PR TITLE
fix --std=gnu++03

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -187,7 +187,8 @@ def detect_compiler():
 
 compiler, version = detect_compiler()
 if compiler == 'g++':
-    flags['CXXFLAGS'].append('--std=gnu++03')
+    if version >= [4, 3, 0]:
+        flags['CXXFLAGS'].append('--std=gnu++03')
     if version >= [4, 9, 0]:
         flags['CCFLAGS'].extend(['-fsanitize=address', '-fvar-tracking-assignments'])
         flags['LINKFLAGS'].extend(['-fsanitize=address'])


### PR DESCRIPTION
gcc before 4.3 does not recognize such a argument but they really support features implied by this arg.