### PR TITLE
remove dependency on libuuid

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -50,7 +50,7 @@ env.Alias('PACK', env.tarball(tarball_name, xs))
 
 env.addExtLib(['protobuf-lite', 'protobuf',
                'ssl', 'crypto',
-               'uuid', 'rt',
+               'rt',
                'boost_system', 'boost_thread', 'boost_chrono'])
 env.subDir('test')
 env.subDir('src')

--- a/doc/user_guide.cn.md
+++ b/doc/user_guide.cn.md
@@ -27,7 +27,7 @@ Windows得益于M记近乎偏执的向后兼容性，可以认为只有一个版
 拿debian8为例，打开`docker/debian8/Dockerfile`，可以看到这样两行：
 
 ```
-RUN apt-get install -y scons g++ libboost-all-dev protobuf-compiler libprotobuf-dev uuid-dev libssl-dev
+RUN apt-get install -y scons g++ libboost-all-dev protobuf-compiler libprotobuf-dev libssl-dev
 RUN apt-get install -y ca-certificates # for HTTPS support
 ```
 
@@ -35,7 +35,6 @@ RUN apt-get install -y ca-certificates # for HTTPS support
 * scons: 编译系统。别问为什么不支持make, cmake, automake, bazar, ... 这么多选择，总得挑一个不是？
 * gcc & boost: 不解释
 * protobuf: 序列化库
-* uuid: 顾名思义
 * openssl: 签名，以及支持HTTPS所用
 * ca-certificates: 仅为支持HTTPS所用。如果您只用表格存储的HTTP地址，可以不安装这个库。不过我们建议还是走HTTPS较为稳妥。
 

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -2,5 +2,5 @@ FROM centos:7
 RUN yum update --assumeyes
 COPY scons-2.5.1-1.noarch.rpm /opt/
 RUN rpm -Uvh /opt/scons-2.5.1-1.noarch.rpm
-RUN yum install --assumeyes protobuf protobuf-devel gcc gcc-c++ openssl-devel libuuid-devel boost-devel
+RUN yum install --assumeyes protobuf protobuf-devel gcc gcc-c++ openssl-devel boost-devel
 WORKDIR /opt/cpp_sdk/

--- a/docker/debian8/Dockerfile
+++ b/docker/debian8/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:8
 RUN apt-get update -y && apt-get clean
 RUN apt-get dist-upgrade -y --no-install-recommends && apt-get clean
-RUN apt-get install -y --no-install-recommends scons g++ libboost-all-dev protobuf-compiler libprotobuf-dev uuid-dev libssl-dev && apt-get clean
+RUN apt-get install -y --no-install-recommends scons g++ libboost-all-dev protobuf-compiler libprotobuf-dev libssl-dev && apt-get clean
 RUN apt-get install -y --no-install-recommends ca-certificates && apt-get clean # for HTTPS support
 WORKDIR /opt/cpp_sdk/

--- a/docker/debian9/Dockerfile
+++ b/docker/debian9/Dockerfile
@@ -1,6 +1,6 @@
 FROM debian:9
 RUN apt-get update -y && apt-get clean
 RUN apt-get dist-upgrade -y --no-install-recommends && apt-get clean
-RUN apt-get install -y --no-install-recommends scons g++ libboost-all-dev protobuf-compiler libprotobuf-dev uuid-dev libssl-dev && apt-get clean
+RUN apt-get install -y --no-install-recommends scons g++ libboost-all-dev protobuf-compiler libprotobuf-dev libssl-dev && apt-get clean
 RUN apt-get install -y --no-install-recommends ca-certificates && apt-get clean # for HTTPS support
 WORKDIR /opt/cpp_sdk/

--- a/src/tablestore/core/SConscript
+++ b/src/tablestore/core/SConscript
@@ -15,5 +15,5 @@ env.Install('$LIB_DIR', [
     env.SharedLibrary('tablestore_core',
                       [public_objs, http_objs, impl_objs, proto_objs, plainbuffer_objs])])
 env.libDeps('tablestore_core_static',
-            ['tablestore_util_static', 'protobuf', 'crypto', 'ssl', 'uuid', 'boost_system'])
+            ['tablestore_util_static', 'protobuf', 'crypto', 'ssl', 'boost_system'])
 

--- a/src/tablestore/core/http/asio.cpp
+++ b/src/tablestore/core/http/asio.cpp
@@ -43,12 +43,13 @@ namespace http {
 
 Asio* Asio::create(
     Logger& logger,
+    Random& rng,
     int64_t maxConnections,
     Duration connectTimeout,
     const Endpoint& ep,
     const deque<shared_ptr<Actor> >& actors)
 {
-    return new AsioImpl(logger, maxConnections, connectTimeout, ep, actors);
+    return new AsioImpl(logger, rng, maxConnections, connectTimeout, ep, actors);
 }
 
 } // namespace http

--- a/src/tablestore/core/http/asio.hpp
+++ b/src/tablestore/core/http/asio.hpp
@@ -119,6 +119,7 @@ public:
 
     static Asio* create(
         util::Logger&,
+        util::Random&,
         int64_t maxConnections,
         util::Duration mConnectTimeout,
         const Endpoint&,

--- a/src/tablestore/core/http/asio_impl.cpp
+++ b/src/tablestore/core/http/asio_impl.cpp
@@ -44,6 +44,7 @@ namespace http {
 
 AsioImpl::AsioImpl(
     Logger& logger,
+    Random& rng,
     int64_t maxConnections,
     Duration connectTimeout,
     const Endpoint& ep,
@@ -51,7 +52,7 @@ AsioImpl::AsioImpl(
   : mLogger(logger),
     mActors(actors),
     mClosed(false),
-    mConnector(*this, ep, maxConnections),
+    mConnector(*this, rng, ep, maxConnections),
     mTimerCenter(mIoService, mLogger, mActors, mSeqGen)
 {
     Thread t(bind(&AsioImpl::loop, this));

--- a/src/tablestore/core/http/asio_impl.hpp
+++ b/src/tablestore/core/http/asio_impl.hpp
@@ -55,10 +55,11 @@ class AsioImpl: public Asio
 {
 public:
     explicit AsioImpl(
-        util::Logger& logger,
+        util::Logger&,
+        util::Random&,
         int64_t maxConnections,
         util::Duration connectTimeout,
-        const Endpoint& ep,
+        const Endpoint&,
         const std::deque<std::tr1::shared_ptr<util::Actor> >&);
     ~AsioImpl();
 

--- a/src/tablestore/core/http/connection_impl.cpp
+++ b/src/tablestore/core/http/connection_impl.cpp
@@ -496,10 +496,12 @@ void Scheduler::WaitForConnection::close()
 
 Connector::Connector(
     AsioImpl& asio,
+    util::Random& rng,
     const Endpoint& ep,
     int64_t maxConnections)
   : mLogger(asio.mutableLogger()),
     mAsio(asio),
+    mRng(rng),
     mEndpoint(ep),
     mMaxConnections(maxConnections),
     mClosed(asio.mutableClosed()),
@@ -589,7 +591,7 @@ void Connector::handleSupplyConnections()
 
 void Connector::connect()
 {
-    Tracker tracker = Tracker::create();
+    Tracker tracker = Tracker::create(mRng);
     OTS_LOG_DEBUG(mLogger)
         ("Connection", tracker)
         .what("CONN: start connecting");

--- a/src/tablestore/core/http/connection_impl.hpp
+++ b/src/tablestore/core/http/connection_impl.hpp
@@ -226,7 +226,11 @@ class Connector
 public:
     typedef Asio::BorrowConnectionHandler BorrowConnectionHandler;
 
-    explicit Connector(AsioImpl&, const Endpoint&, int64_t maxConnections);
+    explicit Connector(
+        AsioImpl&,
+        util::Random&,
+        const Endpoint&,
+        int64_t maxConnections);
     ~Connector();
 
     void start();
@@ -281,6 +285,7 @@ private:
 private:
     util::Logger& mLogger;
     AsioImpl& mAsio;
+    util::Random& mRng;
     const Endpoint mEndpoint;
     const int64_t mMaxConnections;
     boost::atomic<bool>& mClosed;

--- a/src/tablestore/core/impl/async_batch_writer.hpp
+++ b/src/tablestore/core/impl/async_batch_writer.hpp
@@ -311,7 +311,7 @@ private:
     util::Semaphore mAggregateSem;
     boost::atomic<bool> mExit;
     boost::atomic<int64_t> mOngoingRequests;
-    std::auto_ptr<util::random::Random> mRng;
+    std::auto_ptr<util::Random> mRng;
     util::Mutex mMutex;
     std::deque<Item> mWaitingList;
     boost::atomic<bool> mShouldBackoff;

--- a/src/tablestore/core/impl/async_client.cpp
+++ b/src/tablestore/core/impl/async_client.cpp
@@ -85,7 +85,7 @@ void go(
 {
     typedef Context<kAction> Ctx;
 
-    Tracker tracker(Tracker::create());
+    Tracker tracker(Tracker::create(base.randomGenerator()));
     auto_ptr<Ctx> ctx(new Ctx(base, tracker, req, cb));
     Optional<OTSError> err = ctx->build(
         ctx->mApiRequest,

--- a/src/tablestore/core/impl/async_client_base.cpp
+++ b/src/tablestore/core/impl/async_client_base.cpp
@@ -119,13 +119,15 @@ AsyncClientBase::AsyncClientBase(
     const string& inst,
     Credential& cr,
     ClientOptions& opts)
-  : mClose(false),
+  : mRng(random::newDefault()),
+    mClose(false),
     mLogger(opts.releaseLogger()),
     mHttpLogger(mLogger->spawn("http")),
     mCredential(util::move(cr)),
     mAsio(
         http::Asio::create(
             *mHttpLogger,
+            *mRng,
             opts.maxConnections(),
             opts.connectTimeout(),
             ep,
@@ -152,7 +154,8 @@ AsyncClientBase::AsyncClientBase(
     const function<http::Client*(const http::Headers&)>& httpClientFactory,
     Credential& cr,
     ClientOptions& opts)
-  : mClose(false),
+  : mRng(random::newDefault()),
+    mClose(false),
     mLogger(opts.releaseLogger()),
     mCredential(util::move(cr)),
     mAsio(asio),
@@ -164,6 +167,11 @@ AsyncClientBase::AsyncClientBase(
     mActors(opts.actors())
 {
     init("testinstance", httpClientFactory);
+}
+
+Random& AsyncClientBase::randomGenerator()
+{
+    return *mRng;
 }
 
 void AsyncClientBase::init(

--- a/src/tablestore/core/impl/async_client_base.hpp
+++ b/src/tablestore/core/impl/async_client_base.hpp
@@ -144,6 +144,7 @@ public:
     util::Logger& mutableLogger();
     const std::deque<std::tr1::shared_ptr<util::Actor> >& actors() const;
     const RetryStrategy& retryStrategy() const;
+    util::Random& randomGenerator();
 
 private:
     void init(
@@ -156,6 +157,7 @@ private:
         const std::deque<util::MemPiece>&);
 
 private:
+    std::auto_ptr<util::Random> mRng;
     boost::atomic<bool> mClose;
     std::auto_ptr<util::Logger> mLogger;
     std::auto_ptr<util::Logger> mHttpLogger;

--- a/src/tablestore/core/impl/sync_client.cpp
+++ b/src/tablestore/core/impl/sync_client.cpp
@@ -76,7 +76,7 @@ Optional<OTSError> go(
     typedef impl::AsyncClientBase::Context<kAction> Context;
     typedef typename impl::ApiTraits<kAction>::ApiResponse Response;
 
-    Tracker tracker(Tracker::create());
+    Tracker tracker(Tracker::create(ac.randomGenerator()));
     Semaphore sem(0);
     Optional<OTSError> err;
     function<void(Optional<OTSError>&, Response&)> cb =

--- a/src/tablestore/core/retry.cpp
+++ b/src/tablestore/core/retry.cpp
@@ -146,7 +146,7 @@ bool RetryStrategy::retriable(Action act, const OTSError& err)
 const Duration DeadlineRetryStrategy::kMaxPauseBase = Duration::fromMsec(400);
 
 DeadlineRetryStrategy::DeadlineRetryStrategy(
-    const shared_ptr<random::Random>& rng,
+    const shared_ptr<Random>& rng,
     Duration timeout)
   : mRandom(rng),
     mTimeout(timeout),
@@ -183,7 +183,7 @@ Duration DeadlineRetryStrategy::nextPause()
 
 
 CountingRetryStrategy::CountingRetryStrategy(
-    const shared_ptr<util::random::Random>& rng,
+    const shared_ptr<Random>& rng,
     int64_t n,
     Duration interval)
   : mRandom(rng),

--- a/src/tablestore/core/retry.hpp
+++ b/src/tablestore/core/retry.hpp
@@ -48,7 +48,7 @@ class DeadlineRetryStrategy: public RetryStrategy
 {
 public:
     explicit DeadlineRetryStrategy(
-        const std::tr1::shared_ptr<util::random::Random>&,
+        const std::tr1::shared_ptr<util::Random>&,
         util::Duration timeout);
 
     DeadlineRetryStrategy* clone() const;
@@ -59,7 +59,7 @@ public:
 private:
     static const util::Duration kMaxPauseBase;
 
-    std::tr1::shared_ptr<util::random::Random> mRandom;
+    std::tr1::shared_ptr<util::Random> mRandom;
     util::Duration mTimeout;
 
     // reset for cloned ones
@@ -72,7 +72,7 @@ class CountingRetryStrategy: public RetryStrategy
 {
 public:
     explicit CountingRetryStrategy(
-        const std::tr1::shared_ptr<util::random::Random>&,
+        const std::tr1::shared_ptr<util::Random>&,
         int64_t n,
         util::Duration interval);
 
@@ -82,7 +82,7 @@ public:
     util::Duration nextPause();
 
 private:
-    std::tr1::shared_ptr<util::random::Random> mRandom;
+    std::tr1::shared_ptr<util::Random> mRandom;
     util::Duration mInterval;
     const int64_t mMaxRetries;
 

--- a/src/tablestore/core/types.cpp
+++ b/src/tablestore/core/types.cpp
@@ -612,7 +612,7 @@ void ClientOptions::reset()
     mRequestTimeout = Duration::fromSec(3);
 
     mRetryStrategy.reset(new DeadlineRetryStrategy(
-            shared_ptr<random::Random>(random::newDefault()),
+            shared_ptr<Random>(random::newDefault()),
             Duration::fromSec(10)));
 
     mActors.clear();

--- a/src/tablestore/core/types.cpp
+++ b/src/tablestore/core/types.cpp
@@ -33,6 +33,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "tablestore/core/retry.hpp"
 #include "tablestore/util/threading.hpp"
 #include "tablestore/util/logger.hpp"
+#include "tablestore/util/network.hpp"
+#include "tablestore/util/arithmetic.hpp"
+#include "tablestore/util/security.hpp"
 #include "tablestore/util/random.hpp"
 #include "tablestore/util/try.hpp"
 #include "tablestore/util/assert.hpp"
@@ -40,9 +43,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <cmath>
 #include <cstdio>
 #include <stdint.h>
-extern "C" {
-#include <uuid/uuid.h>
-}
 
 using namespace std;
 using namespace std::tr1;
@@ -532,33 +532,32 @@ Optional<OTSError> Credential::validate() const
     return Optional<OTSError>();
 }
 
+namespace {
+
+uint64_t getTrackerBase()
+{
+    Adler32 adler;
+    const string& hostname = getHostName();
+    FOREACH_ITER(i, hostname) {
+        adler.update(static_cast<uint8_t>(*i));
+    }
+    uint32_t hd = adler.get();
+    uint16_t fold = (hd >> 16) ^ hd;
+    uint64_t res = fold;
+    res <<= 48;
+    return res;
+}
+
+} // namespace
 
 Tracker Tracker::create(Random& rng)
 {
-    static const char kCharset[] = "0123456789abcdef";
-
-    uuid_t uuid;
-    uuid_generate(uuid);
-
-    string str;
-    str.reserve(37); // 16*2(char) + 4('-') + 1('\0')
-    for(int64_t i = 0; i < 16; ++i) {
-        uint8_t low = static_cast<uint8_t>(uuid[i]) & 0xF;
-        uint8_t high = static_cast<uint8_t>(uuid[i]) >> 8;
-        str.push_back(kCharset[high]);
-        str.push_back(kCharset[low]);
-        switch(i) {
-        case 3: case 5: case 7: case 9: {
-            str.push_back('-');
-            break;
-        }
-        default: {
-            // intend to do nothing
-        }
-        }
-    }
-
-    return Tracker(str);
+    static uint64_t sBase = getTrackerBase();
+    uint64_t res = random::nextInt(rng, 0x1000000000000ul);
+    res |= sBase;
+    string s;
+    base57encode(s, res);
+    return Tracker(s);
 }
 
 Tracker& Tracker::operator=(const MoveHolder<Tracker>& a)

--- a/src/tablestore/core/types.cpp
+++ b/src/tablestore/core/types.cpp
@@ -533,7 +533,7 @@ Optional<OTSError> Credential::validate() const
 }
 
 
-Tracker Tracker::create()
+Tracker Tracker::create(Random& rng)
 {
     static const char kCharset[] = "0123456789abcdef";
 

--- a/src/tablestore/core/types.hpp
+++ b/src/tablestore/core/types.hpp
@@ -41,6 +41,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "tablestore/util/result.hpp"
 #include "tablestore/util/timestamp.hpp"
 #include "tablestore/util/logger.hpp"
+#include "tablestore/util/random.hpp"
 #include <boost/noncopyable.hpp>
 #include <tr1/memory>
 #include <string>
@@ -373,7 +374,7 @@ public:
 
     Tracker& operator=(const util::MoveHolder<Tracker>& a);
 
-    static Tracker create();
+    static Tracker create(util::Random&);
 
     util::Optional<OTSError> validate() const;
     void prettyPrint(std::string&) const;

--- a/src/tablestore/util/arithmetic.cpp
+++ b/src/tablestore/util/arithmetic.cpp
@@ -109,7 +109,7 @@ void hex(string& out, const MemPiece& in)
 namespace impl {
 static const char kBase57Alphabet[] =
     "0123456789abcdefghijkmnopqrstvwxyzABCDEFGHJKLMNPQRSTVWXYZ";
-static const int64_t kBase57decode[] = {
+static const int64_t kBase57Decode[] = {
     0, 1, 2, 3, 4, 5, 6, 7, 8, 9, -1, -1, -1, -1, -1, -1, -1, 34, 35, 36, 37,
     38, 39, 40, 41, -1, 42, 43, 44, 45, 46, -1, 47, 48, 49, 50, 51, -1, 52, 53,
     54, 55, 56, -1, -1, -1, -1, -1, -1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
@@ -117,9 +117,11 @@ static const int64_t kBase57decode[] = {
 
 uint8_t base57decode(char in)
 {
-    OTS_ASSERT('0' <= in && in <= 'z')
+    OTS_ASSERT('0' <= in)
         (static_cast<int>(in));
-    int64_t i = kBase57decode[in - '0'];
+    OTS_ASSERT(static_cast<size_t>(in - '0') < sizeof(kBase57Decode) / sizeof(kBase57Decode[0]))
+        (static_cast<int>(in));
+    int64_t i = kBase57Decode[in - '0'];
     OTS_ASSERT(i >= 0)
         (static_cast<int>(in));
     return i;
@@ -147,6 +149,9 @@ uint64_t base57decode(const MemPiece& in)
     const uint8_t* s = in.data();
     const uint8_t* e = s + in.length();
     for(; s < e; ++s) {
+        OTS_ASSERT(out * 57 / 57 == out)
+            (out)
+            .what("overflow");
         out *= 57;
         out += impl::base57decode(static_cast<char>(*s));
     }

--- a/src/tablestore/util/arithmetic.cpp
+++ b/src/tablestore/util/arithmetic.cpp
@@ -106,6 +106,47 @@ void hex(string& out, const MemPiece& in)
     }
 }
 
+namespace impl {
+static const char kBase57Alphabet[] =
+    "0123456789abcdefghijkmnopqrstvwxyzABCDEFGHJKLMNPQRSTVWXYZ";
+
+uint8_t base57decode(char in)
+{
+    const char* p = find(kBase57Alphabet, kBase57Alphabet + 57, in);
+    OTS_ASSERT(p < kBase57Alphabet + 57)
+        (in)
+        (p - kBase57Alphabet);
+    return p - kBase57Alphabet;
+}
+
+} // namespace impl
+
+void base57encode(string& out, uint64_t in)
+{
+    if (in == 0) {
+        out.push_back('0');
+        return;
+    }
+    for(; in > 0; in /= 57) {
+        out.push_back(impl::kBase57Alphabet[in % 57]);
+    }
+    for(int64_t left = 0, right = out.size() - 1; left < right; ++left, --right) {
+        swap(out[left], out[right]);
+    }
+}
+
+uint64_t base57decode(const MemPiece& in)
+{
+    uint64_t out = 0;
+    const uint8_t* s = in.data();
+    const uint8_t* e = s + in.length();
+    for(; s < e; ++s) {
+        out *= 57;
+        out += impl::base57decode(static_cast<char>(*s));
+    }
+    return out;
+}
+
 } // namespace util
 } // namespace tablestore
 } // namespace aliyun

--- a/src/tablestore/util/arithmetic.cpp
+++ b/src/tablestore/util/arithmetic.cpp
@@ -109,14 +109,20 @@ void hex(string& out, const MemPiece& in)
 namespace impl {
 static const char kBase57Alphabet[] =
     "0123456789abcdefghijkmnopqrstvwxyzABCDEFGHJKLMNPQRSTVWXYZ";
+static const int64_t kBase57decode[] = {
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9, -1, -1, -1, -1, -1, -1, -1, 34, 35, 36, 37,
+    38, 39, 40, 41, -1, 42, 43, 44, 45, 46, -1, 47, 48, 49, 50, 51, -1, 52, 53,
+    54, 55, 56, -1, -1, -1, -1, -1, -1, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+    20, -1, 21, 22, 23, 24, 25, 26, 27, 28, -1, 29, 30, 31, 32, 33};
 
 uint8_t base57decode(char in)
 {
-    const char* p = find(kBase57Alphabet, kBase57Alphabet + 57, in);
-    OTS_ASSERT(p < kBase57Alphabet + 57)
-        (in)
-        (p - kBase57Alphabet);
-    return p - kBase57Alphabet;
+    OTS_ASSERT('0' <= in && in <= 'z')
+        (static_cast<int>(in));
+    int64_t i = kBase57decode[in - '0'];
+    OTS_ASSERT(i >= 0)
+        (static_cast<int>(in));
+    return i;
 }
 
 } // namespace impl

--- a/src/tablestore/util/arithmetic.hpp
+++ b/src/tablestore/util/arithmetic.hpp
@@ -45,6 +45,18 @@ Optional<std::string> toUint64(uint64_t&, const MemPiece&, int64_t radix);
 void format(std::string&, uint64_t num, int64_t radix);
 void hex(std::string&, const MemPiece&);
 
+/**
+ * Convert a 64-bit integer into base 57 using
+ * 0123456789abcdefghijkmnopqrstvwxyzABCDEFGHJKLMNPQRSTVWXYZ
+ * 
+ * Lower-case "L" (l), capital "I" (I), and the capital letter "O" (O) are 
+ * excluded to prevent ambiguous values. Both capital and lower-case "U" 
+ * (u and U) are excluded to prevent the most egregious accidental profanity.
+ *
+ */
+void base57encode(std::string&, uint64_t);
+uint64_t base57decode(const MemPiece&);
+
 } // namespace util
 } // namespace tablestore
 } // namespace aliyun

--- a/src/tablestore/util/network.cpp
+++ b/src/tablestore/util/network.cpp
@@ -19,9 +19,10 @@ namespace util {
 string getHostName()
 {
     string res;
-    // SUSv2 or Windows guarantees that "Host names are limited to 255 bytes".
-    res.reserve(256); 
-    int r = gethostname(const_cast<char*>(res.data()), res.capacity());
+    // Windows guarantees that "Host names are limited to 255 bytes".
+    // Linux limits it by 64.
+    res.resize(255); 
+    int r = ::gethostname(&res[0], res.size());
 #if defined(_MSC_VER)
     OTS_ASSERT(r == 0)
         (r)

--- a/src/tablestore/util/network.cpp
+++ b/src/tablestore/util/network.cpp
@@ -1,0 +1,43 @@
+#include "network.hpp"
+#include "tablestore/util/assert.hpp"
+#include <cstring>
+#if defined(_MSC_VER)
+#include <winsock.h>
+#else
+#include <cerrno>
+extern "C" {
+#include <unistd.h>
+}
+#endif
+
+using namespace std;
+
+namespace aliyun {
+namespace tablestore {
+namespace util {
+
+string getHostName()
+{
+    string res;
+    // SUSv2 or Windows guarantees that "Host names are limited to 255 bytes".
+    res.reserve(256); 
+    int r = gethostname(const_cast<char*>(res.data()), res.capacity());
+#if defined(_MSC_VER)
+    OTS_ASSERT(r == 0)
+        (r)
+        (WSAGetLastError())
+        .what("failed to fetch hostname.");
+#else
+    OTS_ASSERT(r == 0)
+        (r)
+        (errno)
+        .what("failed to fetch hostname.");
+#endif
+    size_t n = strnlen(res.data(), res.capacity());
+    res.resize(n);
+    return res;
+}
+
+} // namespace util
+} // namespace tablestore
+} // namespace aliyun

--- a/src/tablestore/util/network.hpp
+++ b/src/tablestore/util/network.hpp
@@ -1,0 +1,53 @@
+#pragma once
+#ifndef TABLESTORE_UTIL_NETWORK_HPP
+#define TABLESTORE_UTIL_NETWORK_HPP
+/*
+BSD 3-Clause License
+
+Copyright (c) 2017, Alibaba Cloud
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#include <string>
+
+namespace aliyun {
+namespace tablestore {
+namespace util {
+
+/**
+ * Get host name of this machine.
+ *
+ * Caveats:
+ * For windows, winsock must be correctly initialized by WSAStartup().
+ */
+std::string getHostName();
+
+} // namespace util
+} // namespace tablestore
+} // namespace aliyun
+
+#endif

--- a/src/tablestore/util/random.hpp
+++ b/src/tablestore/util/random.hpp
@@ -39,7 +39,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 namespace aliyun {
 namespace tablestore {
 namespace util {
-namespace random {
 
 class Random
 {
@@ -51,6 +50,8 @@ public:
     virtual uint64_t upperBound() const =0;
     virtual uint64_t seed() const =0;
 };
+
+namespace random {
 
 Random* newDefault();
 Random* newDefault(uint64_t seed);

--- a/test/unittest/core/async_client_unittest.cpp
+++ b/test/unittest/core/async_client_unittest.cpp
@@ -435,6 +435,7 @@ public:
     ClientOptions mOpts;
     Logger* mLogger;
     Actor* mActor;
+    auto_ptr<Random> mRng;
 
     MasterSlave mMasterSlave;
     Master& mMaster;
@@ -452,11 +453,12 @@ public:
 TestBench::TestBench(RetryStrategy* rs)
   : mLogger(NULL),
     mActor(NULL),
+    mRng(random::newDefault()),
     mMasterSlave(),
     mMaster(mMasterSlave.master()),
     mSlave(mMasterSlave.slave()),
-    mTracker(Tracker::create()),
-    mRequestId(Tracker::create().traceId())
+    mTracker(Tracker::create(*mRng)),
+    mRequestId(Tracker::create(*mRng).traceId())
 {
     if (rs != NULL) {
         mOpts.resetRetryStrategy(rs);

--- a/test/unittest/core/plainbuffer_unittest.cpp
+++ b/test/unittest/core/plainbuffer_unittest.cpp
@@ -78,7 +78,7 @@ TESTA_DEF_JUNIT_LIKE1(Crc8);
 namespace {
 void Crc8_U32(const string&)
 {
-    auto_ptr<random::Random> rng(random::newDefault(0));
+    auto_ptr<Random> rng(random::newDefault(0));
     for(int i = 0; i < 10000; ++i) {
         uint32_t in = random::nextInt(*rng, numeric_limits<uint32_t>::max());
         uint8_t oracle = PlainBufferCrc8::CrcInt32(0, in);
@@ -94,7 +94,7 @@ void Crc8_U32(const string&)
 TESTA_DEF_JUNIT_LIKE1(Crc8_U32);
 
 namespace {
-uint64_t randomU64(random::Random& rng)
+uint64_t randomU64(Random& rng)
 {
     uint64_t res = 0;
     for(int i = 0; i < 4; ++i) {
@@ -106,7 +106,7 @@ uint64_t randomU64(random::Random& rng)
 
 void Crc8_U64(const string&)
 {
-    auto_ptr<random::Random> rng(random::newDefault(0));
+    auto_ptr<Random> rng(random::newDefault(0));
     for(int i = 0; i < 10000; ++i) {
         uint64_t in = randomU64(*rng);
         uint8_t oracle = PlainBufferCrc8::CrcInt64(0, in);
@@ -124,7 +124,7 @@ TESTA_DEF_JUNIT_LIKE1(Crc8_U64);
 namespace {
 const string kAlphabet("abcdefgh.");
 
-void randomStr(random::Random& rng, string& out, const string& alphabet, char terminator)
+void randomStr(Random& rng, string& out, const string& alphabet, char terminator)
 {
     for(;;) {
         char c = alphabet[random::nextInt(rng, alphabet.size())];
@@ -137,7 +137,7 @@ void randomStr(random::Random& rng, string& out, const string& alphabet, char te
 
 void Crc8_Str(const string&)
 {
-    auto_ptr<random::Random> rng(random::newDefault());
+    auto_ptr<Random> rng(random::newDefault());
     cout << "seed: " << rng->seed() << endl;
     for(int64_t i = 0; i < 10000; ++i) {
         string in;
@@ -156,7 +156,7 @@ TESTA_DEF_JUNIT_LIKE1(Crc8_Str);
 
 namespace {
 
-int64_t randomChoice(random::Random& rng, const deque<int64_t>& weights)
+int64_t randomChoice(Random& rng, const deque<int64_t>& weights)
 {
     int64_t total = accumulate(weights.begin(), weights.end(), 0);
     OTS_ASSERT(total > 0)(total);
@@ -173,7 +173,7 @@ int64_t randomChoice(random::Random& rng, const deque<int64_t>& weights)
     return 0;
 }
 
-void randomName(random::Random& rng, string& out)
+void randomName(Random& rng, string& out)
 {
     for(;;) {
         char c = kAlphabet[random::nextInt(rng, kAlphabet.size())];
@@ -185,7 +185,7 @@ void randomName(random::Random& rng, string& out)
     randomStr(rng, out, kAlphabet, '.');
 }
 
-void randomPrimaryKeyValue(random::Random& rng, PrimaryKeyValue& out)
+void randomPrimaryKeyValue(Random& rng, PrimaryKeyValue& out)
 {
     deque<PrimaryKeyType> types;
     types.push_back(kPKT_Integer);
@@ -205,13 +205,13 @@ void randomPrimaryKeyValue(random::Random& rng, PrimaryKeyValue& out)
     }
 }
 
-void randomPrimaryKeyColumn(random::Random& rng, PrimaryKeyColumn& out)
+void randomPrimaryKeyColumn(Random& rng, PrimaryKeyColumn& out)
 {
     randomName(rng, out.mutableName());
     randomPrimaryKeyValue(rng, out.mutableValue());
 }
 
-void randomPrimaryKey(random::Random& rng, PrimaryKey& out)
+void randomPrimaryKey(Random& rng, PrimaryKey& out)
 {
     deque<int64_t> weights;
     weights.push_back(8);
@@ -224,7 +224,7 @@ void randomPrimaryKey(random::Random& rng, PrimaryKey& out)
     }
 }
 
-void randomAttrValue(random::Random& rng, AttributeValue& out)
+void randomAttrValue(Random& rng, AttributeValue& out)
 {
     deque<AttributeValue::Category> types;
     types.push_back(AttributeValue::kString);
@@ -255,7 +255,7 @@ void randomAttrValue(random::Random& rng, AttributeValue& out)
     }
 }
 
-void randomAttr(random::Random& rng, Attribute& out)
+void randomAttr(Random& rng, Attribute& out)
 {
     randomName(rng, out.mutableName());
     randomAttrValue(rng, out.mutableValue());
@@ -264,7 +264,7 @@ void randomAttr(random::Random& rng, Attribute& out)
     }
 }
 
-void randomAttrs(random::Random& rng, IVector<Attribute>& out)
+void randomAttrs(Random& rng, IVector<Attribute>& out)
 {
     string lenStr;
     randomStr(rng, lenStr, "+++++.", '.');
@@ -273,7 +273,7 @@ void randomAttrs(random::Random& rng, IVector<Attribute>& out)
     }
 }
 
-void randomRow(random::Random& rng, Row& out)
+void randomRow(Random& rng, Row& out)
 {
     out.reset();
     randomPrimaryKey(rng, out.mutablePrimaryKey());
@@ -290,7 +290,7 @@ void to(RowPutChange& out, const Row& in)
 
 void PlainBuffer_Deserialize_RandomRow(const string&)
 {
-    auto_ptr<random::Random> rng(random::newDefault());
+    auto_ptr<Random> rng(random::newDefault());
     cout << "seed: " << rng->seed() << endl;
     for(int64_t repeat = 10000; repeat > 0; --repeat) {
         Row oracle;
@@ -439,7 +439,7 @@ TESTA_DEF_JUNIT_LIKE1(PlainBuffer_Deserialize_Header_Error);
 namespace {
 void PlainBuffer_Serialize_RandomAttributeValue(const string&)
 {
-    auto_ptr<random::Random> rng(random::newDefault());
+    auto_ptr<Random> rng(random::newDefault());
     cout << "seed: " << rng->seed() << endl;
     for(int64_t repeat = 10000; repeat > 0; --repeat) {
         AttributeValue val;
@@ -461,7 +461,7 @@ TESTA_DEF_JUNIT_LIKE1(PlainBuffer_Serialize_RandomAttributeValue);
 namespace {
 void PlainBuffer_Serialize_RandomPrimaryKeyValue(const string&)
 {
-    auto_ptr<random::Random> rng(random::newDefault());
+    auto_ptr<Random> rng(random::newDefault());
     cout << "seed: " << rng->seed() << endl;
     for(int64_t repeat = 10000; repeat > 0; --repeat) {
         PrimaryKeyValue val;
@@ -570,7 +570,7 @@ void shrink(const Row& row, const function<bool(const Row&)>& test)
 
 void PlainBuffer_Serialize_RandomRowPutChange(const string&)
 {
-    auto_ptr<random::Random> rng(random::newDefault());
+    auto_ptr<Random> rng(random::newDefault());
     cout << "seed: " << rng->seed() << endl;
     for(int64_t repeat = 10000; repeat > 0; --repeat) {
         Row row;
@@ -609,7 +609,7 @@ bool testRowDeleteChange(const PrimaryKey& pkey)
 
 void PlainBuffer_Serialize_RandomRowDeleteChange(const string&)
 {
-    auto_ptr<random::Random> rng(random::newDefault());
+    auto_ptr<Random> rng(random::newDefault());
     cout << "seed: " << rng->seed() << endl;
     for(int64_t repeat = 10000; repeat > 0; --repeat) {
         PrimaryKey pkey;
@@ -639,7 +639,7 @@ bool testRowUpdateChange(const RowUpdateChange& chg)
     }
 }
 
-void randomPutCell(random::Random& rng, RowUpdateChange::Update& out)
+void randomPutCell(Random& rng, RowUpdateChange::Update& out)
 {
     out.mutableType() = RowUpdateChange::Update::kPut;
     randomName(rng, out.mutableAttrName());
@@ -652,7 +652,7 @@ void randomPutCell(random::Random& rng, RowUpdateChange::Update& out)
     }
 }
 
-void randomDelCell(random::Random& rng, RowUpdateChange::Update& out)
+void randomDelCell(Random& rng, RowUpdateChange::Update& out)
 {
     out.mutableType() = RowUpdateChange::Update::kDelete;
     randomName(rng, out.mutableAttrName());
@@ -662,13 +662,13 @@ void randomDelCell(random::Random& rng, RowUpdateChange::Update& out)
     }
 }
 
-void randomDelCol(random::Random& rng, RowUpdateChange::Update& out)
+void randomDelCol(Random& rng, RowUpdateChange::Update& out)
 {
     out.mutableType() = RowUpdateChange::Update::kDeleteAll;
     randomName(rng, out.mutableAttrName());
 }
 
-void randomRowUpdateChange(random::Random& rng, RowUpdateChange& out)
+void randomRowUpdateChange(Random& rng, RowUpdateChange& out)
 {
     randomPrimaryKey(rng, out.mutablePrimaryKey());
     string pat;
@@ -745,7 +745,7 @@ void shrink(
 
 void PlainBuffer_Serialize_RandomRowUpdateChange(const string&)
 {
-    auto_ptr<random::Random> rng(random::newDefault());
+    auto_ptr<Random> rng(random::newDefault());
     cout << "seed: " << rng->seed() << endl;
     for(int64_t repeat = 10000; repeat > 0; --repeat) {
         RowUpdateChange chg;
@@ -762,7 +762,7 @@ TESTA_DEF_JUNIT_LIKE1(PlainBuffer_Serialize_RandomRowUpdateChange);
 namespace {
 void PlainBuffer_Serialize_RandomPrimaryKey(const string&)
 {
-    auto_ptr<random::Random> rng(random::newDefault());
+    auto_ptr<Random> rng(random::newDefault());
     cout << "seed: " << rng->seed() << endl;
     for(int64_t repeat = 10000; repeat > 0; --repeat) {
         PrimaryKey pk;

--- a/test/unittest/util/arithmetic_unittest.cpp
+++ b/test/unittest/util/arithmetic_unittest.cpp
@@ -101,5 +101,38 @@ void to_uint64_verifier(const uint64_t& res, const tuple<uint64_t, int>& in)
 TESTA_DEF_VERIFY_WITH_TB(ToUnt64_UpperCase, to_uint64_tb, to_uint64_verifier, to_uint64_uppercase);
 TESTA_DEF_VERIFY_WITH_TB(ToUnt64_LowerCase, to_uint64_tb, to_uint64_verifier, to_uint64_lowercase);
 
+void Base57_0(const string&)
+{
+    string out;
+    base57encode(out, 0);
+    TESTA_ASSERT(out == "0")
+        (out).issue();
+}
+TESTA_DEF_JUNIT_LIKE1(Base57_0);
+
+void Base57_bFCnz(const string&)
+{
+    string out;
+    base57encode(out, 123456789ULL);
+    TESTA_ASSERT(out == "bFCnz")
+        (out).issue();
+}
+TESTA_DEF_JUNIT_LIKE1(Base57_bFCnz);
+
+void Base57_range(const string&)
+{
+    string out;
+    for(uint64_t orc = 0; orc < 100000; ++orc) {
+        out.clear();
+        base57encode(out, orc);
+        uint64_t trial = base57decode(MemPiece::from(out));
+        TESTA_ASSERT(trial == orc)
+            (trial)
+            (orc)
+            .issue();
+    }
+}
+TESTA_DEF_JUNIT_LIKE1(Base57_range);
+
 } // namespace tablestore
 } // namespace aliyun

--- a/test/unittest/util/mempool_unittest.cpp
+++ b/test/unittest/util/mempool_unittest.cpp
@@ -141,7 +141,7 @@ namespace {
 
 void MemPool_tester(
     boost::atomic<bool>* stopper,
-    random::Random& rng,
+    Random& rng,
     MemPool* mpool)
 {
     for(;;) {
@@ -159,7 +159,7 @@ void MemPool_tester(
 void IncrementalMemPool_Nthreads(const string&)
 {
     IncrementalMemPool mp;
-    auto_ptr<random::Random> rng(random::newDefault(0));
+    auto_ptr<Random> rng(random::newDefault(0));
     boost::atomic<bool> stopper;
     boost::thread_group testers;
     for(int i = 0; i < 32; ++i) {
@@ -180,7 +180,7 @@ namespace {
 
 void StrPool_tester(
     boost::atomic<bool>& stopper,
-    random::Random& rng,
+    Random& rng,
     StrPool& spool)
 {
     for(;;) {
@@ -198,7 +198,7 @@ void StrPool_tester(
 void StrPool_Nthreads(const string&)
 {
     StrPool sp;
-    auto_ptr<random::Random> rng(random::newDefault());
+    auto_ptr<Random> rng(random::newDefault());
     boost::atomic<bool> stopper;
     boost::thread_group testers;
     for(int i = 0; i < 32; ++i) {

--- a/test/unittest/util/random_unittest.cpp
+++ b/test/unittest/util/random_unittest.cpp
@@ -50,7 +50,7 @@ namespace tablestore {
 
 namespace {
 
-void genSamples(random::Random& rng, deque<uint64_t>& samples, const uint64_t bits)
+void genSamples(Random& rng, deque<uint64_t>& samples, const uint64_t bits)
 {
     for(int64_t i = 0; i < 20000; ++i) {
         samples.push_back(random::nextInt(rng, 1ULL << bits));
@@ -152,7 +152,7 @@ void check2d(
 void Random_Small(const string&)
 {
     const uint64_t kBits = 8;
-    auto_ptr<random::Random> rng(random::newDefault());
+    auto_ptr<Random> rng(random::newDefault());
     deque<uint64_t> samples;
     genSamples(*rng, samples, kBits);
     deque<int64_t> counts1d;
@@ -172,7 +172,7 @@ namespace {
 void Random_Large(const string&)
 {
     const uint64_t kBits = 48;
-    auto_ptr<random::Random> rng(random::newDefault());
+    auto_ptr<Random> rng(random::newDefault());
     cerr << rng->upperBound() << endl;
     deque<uint64_t> samples;
     genSamples(*rng, samples, kBits);
@@ -192,7 +192,7 @@ TESTA_DEF_JUNIT_LIKE1(Random_Large);
 namespace {
 void Random_NegativeLower(const string&)
 {
-    auto_ptr<random::Random> rng(random::newDefault());
+    auto_ptr<Random> rng(random::newDefault());
     deque<int64_t> samples;
     for(int64_t i = 0; i < 10000; ++i) {
         samples.push_back(random::nextInt(*rng, -1, 1));


### PR DESCRIPTION
This enables possibility to support windows.

To do this, I also change the following things:
1. move util::random::Random to util, to reduce typing boring "random::"s.
2. put util::Random to Tracker::create() to eliminate hidden random generators.
3. new tracker-id generation algorithm which is strong enough, I think, in this SDK's context.